### PR TITLE
chore: update jsonwebtoken

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ sha2 = { version = "=0.11.0-pre.3", optional = true }
 
 bs58 = { version = "0.5", optional = true }
 ring = { version = "0.17", optional = true }
-jsonwebtoken = { version = "9.3", optional = true }
+jsonwebtoken = { version = "10.3", optional = true }
 
 http = { version = "1.3", optional = true }
 


### PR DESCRIPTION
10.3 fixes a type confusion vulnerability: https://github.com/Keats/jsonwebtoken/blob/master/CHANGELOG.md#1030-2026-01-27