### PR TITLE
Switch jsonwebtoken to aws-lc-rs backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = { version = "=0.11.0-rc.5", optional = true }
 
 bs58 = { version = "0.5", optional = true }
-jsonwebtoken = { version = "10.3", default-features = false, features = ["rust_crypto"], optional = true }
+jsonwebtoken = { version = "10.3", default-features = false, features = ["aws_lc_rs"], optional = true }
 
 http = { version = "1.3", optional = true }
 
@@ -36,4 +36,4 @@ assert2 = "0.4.0"
 prost-build = "0.14"
 rstest = "0.26.1"
 ed25519-dalek = { version = "2", features = ["pkcs8", "rand_core"] }
-rand = "0.8"
+rand_core = { version = "0.6", features = ["getrandom"] }

--- a/src/request_identity.rs
+++ b/src/request_identity.rs
@@ -164,7 +164,7 @@ mod tests {
 
     use ed25519_dalek::pkcs8::EncodePrivateKey;
     use ed25519_dalek::SigningKey;
-    use rand::rngs::OsRng;
+    use rand_core::OsRng;
     use serde::Serialize;
     use std::time::SystemTime;
 


### PR DESCRIPTION
Avoid the vulnerable rand 0.8.5 dependency path by using jsonwebtoken's aws_lc_rs backend and replacing the test-only rand dependency with rand_core. This keeps request identity verification on a maintained crypto backend without changing behavior.