### PR TITLE
Allow consumers to choose the jsonwebtoken crypto backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/restatedev/sdk-shared-core"
 default = []
 request_identity = ["dep:jsonwebtoken", "dep:bs58"]
 sha2_random_seed = ["dep:sha2"]
+# jsonwebtoken crypto backend pass-through. Enable exactly one alongside
+# request_identity (or call jsonwebtoken's CryptoProvider::install_default yourself).
+rust_crypto = ["jsonwebtoken?/rust_crypto"]
+aws_lc_rs = ["jsonwebtoken?/aws_lc_rs"]
 
 [dependencies]
 thiserror = "2.0"
@@ -25,7 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = { version = "0.11.0", optional = true }
 
 bs58 = { version = "0.5", optional = true }
-jsonwebtoken = { version = "10.3", default-features = false, features = ["rust_crypto"], optional = true }
+jsonwebtoken = { version = "10.3", default-features = false, optional = true }
 
 http = { version = "1.3", optional = true }
 

--- a/src/request_identity.rs
+++ b/src/request_identity.rs
@@ -168,6 +168,13 @@ mod tests {
     use serde::Serialize;
     use std::time::SystemTime;
 
+    fn install_crypto_provider() {
+        #[cfg(feature = "rust_crypto")]
+        let _ = jsonwebtoken::crypto::rust_crypto::DEFAULT_PROVIDER.install_default();
+        #[cfg(all(feature = "aws_lc_rs", not(feature = "rust_crypto")))]
+        let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+    }
+
     #[derive(Serialize)]
     pub(crate) struct Claims<'aud> {
         aud: &'aud str,
@@ -178,6 +185,7 @@ mod tests {
 
     #[test]
     fn verify() {
+        install_crypto_provider();
         let (jwt, identity_key) = mock_token_and_key();
 
         let verifier = IdentityVerifier::new(&[&identity_key]).unwrap();
@@ -197,6 +205,7 @@ mod tests {
 
     #[test]
     fn bad_key() {
+        install_crypto_provider();
         let verifier =
             IdentityVerifier::new(&["publickeyv1_ChjENKeMvCtRnqG2mrBK1HmPKufgFUc98K8B3ononQvp"])
                 .unwrap();


### PR DESCRIPTION
The request_identity feature previously enabled jsonwebtoken with the rust_crypto feature baked in. If a consuming workspace also pulls in jsonwebtoken with aws_lc_rs enabled, Cargo feature unification turns both on and jsonwebtoken's provider auto-detection panics at first use.

request_identity only needs EdDSA, which both backends support, so this change drops the hardcoded backend and exposes rust_crypto / aws_lc_rs as pass-through features (the same pattern rustls and tokio-rustls use). Consumers enable exactly one, or call CryptoProvider::install_default themselves.

The request_identity tests now install a provider explicitly so that cargo test --all-features (which enables both backends) keeps working.