### PR TITLE
Fix sys_run interface to return whether the run was replayed or not.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,6 +376,19 @@ pub enum State {
     Closed = 3,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct AwakeableHandle {
+    pub id: String,
+    pub handle: NotificationHandle,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RunHandle {
+    /// If true, the run result will be replayed, meaning the SDK don't need to schedule the closure for execution.
+    pub replayed: bool,
+    pub handle: NotificationHandle,
+}
+
 pub trait VM: Sized {
     fn new(request_headers: impl HeaderMap, options: VMOptions) -> VMResult<Self>;
 
@@ -451,7 +464,7 @@ pub trait VM: Sized {
         options: PayloadOptions,
     ) -> VMResult<SendHandle>;
 
-    fn sys_awakeable(&mut self) -> VMResult<(String, NotificationHandle)>;
+    fn sys_awakeable(&mut self) -> VMResult<AwakeableHandle>;
 
     fn sys_complete_awakeable(
         &mut self,
@@ -480,7 +493,7 @@ pub trait VM: Sized {
         options: PayloadOptions,
     ) -> VMResult<NotificationHandle>;
 
-    fn sys_run(&mut self, name: String) -> VMResult<NotificationHandle>;
+    fn sys_run(&mut self, name: String) -> VMResult<RunHandle>;
 
     fn propose_run_completion(
         &mut self,

--- a/src/tests/async_result.rs
+++ b/src/tests/async_result.rs
@@ -132,7 +132,7 @@ fn await_twice_the_same_handle() {
         .run_without_closing_input(|vm, _| {
             vm.sys_input().unwrap();
 
-            let (_, h) = vm.sys_awakeable().unwrap();
+            let h = vm.sys_awakeable().unwrap().handle;
 
             assert_eq!(
                 vm.do_await(h.into()).unwrap(),
@@ -216,7 +216,7 @@ mod do_await {
 
             let mut handles = Vec::with_capacity(n);
             for _ in 0..n {
-                let (_, h) = vm.sys_awakeable().unwrap();
+                let h = vm.sys_awakeable().unwrap().handle;
                 handles.push(h);
             }
 
@@ -715,9 +715,9 @@ fn awaiting_on_shrinks_across_calls() {
         .run_without_closing_input(|vm, encoder| {
             vm.sys_input().unwrap();
 
-            let (_, h1) = vm.sys_awakeable().unwrap(); // signal 17
-            let (_, h2) = vm.sys_awakeable().unwrap(); // signal 18
-            let (_, h3) = vm.sys_awakeable().unwrap(); // signal 19
+            let h1 = vm.sys_awakeable().unwrap().handle; // signal 17
+            let h2 = vm.sys_awakeable().unwrap().handle; // signal 18
+            let h3 = vm.sys_awakeable().unwrap().handle; // signal 19
 
             let fut = || all_completed!(h1, h2, h3);
 

--- a/src/tests/failures.rs
+++ b/src/tests/failures.rs
@@ -690,7 +690,7 @@ mod journal_mismatch {
             .run(|vm| {
                 vm.sys_input().unwrap();
 
-                let run_handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+                let run_handle = vm.sys_run("my-side-effect".to_owned()).unwrap().handle;
 
                 // On await, this is the expected error
                 assert_that!(
@@ -821,7 +821,7 @@ mod journal_mismatch {
                 //
                 // Otherwise the notification for the awakeable should be in the journal before the second awakeable!
 
-                let (_, awakeable_handle) = vm.sys_awakeable().unwrap();
+                let awakeable_handle = vm.sys_awakeable().unwrap().handle;
 
                 // On await, this is the expected error
                 assert_that!(

--- a/src/tests/run.rs
+++ b/src/tests/run.rs
@@ -23,7 +23,8 @@ fn enter_then_propose_completion_then_suspend() {
         .run_without_closing_input(|vm, _| {
             vm.sys_input().unwrap();
 
-            let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            let RunHandle { replayed, handle } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            assert!(!replayed);
 
             assert_eq!(
                 vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
@@ -113,7 +114,8 @@ fn enter_then_propose_completion_then_complete() {
         .run_without_closing_input(|vm, encoder| {
             vm.sys_input().unwrap();
 
-            let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            let RunHandle { replayed, handle } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            assert!(!replayed);
             assert_eq!(
                 vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
                 AwaitResponse::ExecuteRun(handle)
@@ -206,7 +208,8 @@ fn enter_then_propose_completion_then_complete_with_failure() {
         .run_without_closing_input(|vm, encoder| {
             vm.sys_input().unwrap();
 
-            let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            let RunHandle { replayed, handle } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            assert!(!replayed);
 
             assert_eq!(
                 vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
@@ -291,7 +294,8 @@ fn enter_then_notify_input_closed_then_propose_completion() {
         .run_without_closing_input(|vm, _| {
             vm.sys_input().unwrap();
 
-            let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            let RunHandle { replayed, handle } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            assert!(!replayed);
             assert_eq!(
                 vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
                 AwaitResponse::ExecuteRun(handle)
@@ -359,7 +363,8 @@ fn replay_without_completion() {
         .run(|vm| {
             vm.sys_input().unwrap();
 
-            let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            let RunHandle { replayed, handle } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            assert!(!replayed);
 
             assert_eq!(
                 vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
@@ -422,7 +427,11 @@ fn replay_without_completion_with_any() {
         .run(|vm| {
             vm.sys_input().unwrap();
 
-            let run_handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            let RunHandle {
+                replayed,
+                handle: run_handle,
+            } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            assert!(!replayed);
             let first_sleep_handle = vm
                 .sys_sleep(Default::default(), Duration::ZERO, None)
                 .unwrap();
@@ -518,7 +527,8 @@ fn replay_with_completion() {
         .run(|vm| {
             vm.sys_input().unwrap();
 
-            let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            let RunHandle { replayed, handle } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            assert!(replayed);
             assert_eq!(
                 vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
                 AwaitResponse::AnyCompleted
@@ -543,6 +553,61 @@ fn replay_with_completion() {
 }
 
 #[test]
+fn replay_with_completion_followed_by_another_command_is_replayed() {
+    let mut output = VMTestCase::new()
+        .input(start_message(4))
+        .input(input_entry_message(b"my-data"))
+        .input(RunCommandMessage {
+            result_completion_id: 1,
+            name: "my-side-effect".to_owned(),
+        })
+        .input(SleepCommandMessage {
+            wake_up_time: 0,
+            result_completion_id: 2,
+            ..Default::default()
+        })
+        .input(RunCompletionNotificationMessage {
+            completion_id: 1,
+            result: Some(run_completion_notification_message::Result::Value(
+                Bytes::from_static(b"123").into(),
+            )),
+        })
+        .run(|vm| {
+            vm.sys_input().unwrap();
+
+            // We're still replaying and the run completion is already buffered,
+            // so the closure must NOT be executed.
+            let RunHandle { replayed, handle } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            assert!(replayed);
+            assert!(vm.state().is_replaying());
+
+            // Replay the trailing command too.
+            let _sleep_handle = vm
+                .sys_sleep(Default::default(), Duration::ZERO, None)
+                .unwrap();
+
+            assert_eq!(
+                vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
+                AwaitResponse::AnyCompleted
+            );
+            let result = vm.take_notification(handle).unwrap().unwrap();
+            assert2::assert!(let Value::Success(s) = result);
+
+            vm.sys_write_output(NonEmptyValue::Success(s), PayloadOptions::default())
+                .unwrap();
+            vm.sys_end().unwrap();
+        });
+
+    // The run was replayed: no RunCommand nor ProposeRunCompletion is emitted.
+    assert_that!(
+        output.next_decoded::<OutputCommandMessage>().unwrap(),
+        is_output_with_success(b"123")
+    );
+    output.next_decoded::<EndMessage>().unwrap();
+    assert_eq!(output.next(), None);
+}
+
+#[test]
 fn enter_then_notify_error() {
     let mut output = VMTestCase::new()
         .input(start_message(1))
@@ -550,7 +615,8 @@ fn enter_then_notify_error() {
         .run(|vm| {
             vm.sys_input().unwrap();
 
-            let _ = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            let RunHandle { replayed, .. } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+            assert!(!replayed);
 
             vm.notify_error(
                 Error::internal(Cow::Borrowed("my-error"))
@@ -595,7 +661,9 @@ mod v7_with_ack {
             .run_without_closing_input(|vm, encoder| {
                 vm.sys_input().unwrap();
 
-                let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+                let RunHandle { replayed, handle } =
+                    vm.sys_run("my-side-effect".to_owned()).unwrap();
+                assert!(!replayed);
                 assert_eq!(
                     vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
                     AwaitResponse::ExecuteRun(handle)
@@ -687,7 +755,9 @@ mod v7_with_ack {
             .run_without_closing_input(|vm, encoder| {
                 vm.sys_input().unwrap();
 
-                let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+                let RunHandle { replayed, handle } =
+                    vm.sys_run("my-side-effect".to_owned()).unwrap();
+                assert!(!replayed);
                 assert_eq!(
                     vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
                     AwaitResponse::ExecuteRun(handle)
@@ -766,7 +836,9 @@ mod v7_with_ack {
             .run_without_closing_input(|vm, encoder| {
                 vm.sys_input().unwrap();
 
-                let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+                let RunHandle { replayed, handle } =
+                    vm.sys_run("my-side-effect".to_owned()).unwrap();
+                assert!(!replayed);
                 assert_eq!(
                     vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
                     AwaitResponse::ExecuteRun(handle)
@@ -864,20 +936,12 @@ mod retry_policy {
                 result_completion_id: 1,
                 name: "my-side-effect".to_string(),
             })
-            .input(RunCompletionNotificationMessage {
-                completion_id: 1,
-                result: Some(run_completion_notification_message::Result::Failure(
-                    Failure {
-                        code: 500,
-                        message: "my-error".to_string(),
-                        metadata: vec![],
-                    },
-                )),
-            })
-            .run(|vm| {
+            .run_without_closing_input(|vm, encoder| {
                 vm.sys_input().unwrap();
 
-                let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+                let RunHandle { replayed, handle } =
+                    vm.sys_run("my-side-effect".to_owned()).unwrap();
+                assert!(!replayed);
                 vm.propose_run_completion(
                     handle,
                     RunExitResult::RetryableFailure {
@@ -887,6 +951,18 @@ mod retry_policy {
                     retry_policy,
                 )
                 .unwrap();
+
+                vm.notify_input(encoder.encode(&RunCompletionNotificationMessage {
+                    completion_id: 1,
+                    result: Some(run_completion_notification_message::Result::Failure(
+                        Failure {
+                            code: 500,
+                            message: "my-error".to_string(),
+                            metadata: vec![],
+                        },
+                    )),
+                }));
+                vm.notify_input_closed();
 
                 assert_eq!(
                     vm.do_await(UnresolvedFuture::Single(handle)).unwrap(),
@@ -948,7 +1024,9 @@ mod retry_policy {
             .input(input_entry_message(b"my-data"))
             .run(|vm| {
                 vm.sys_input().unwrap();
-                let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+                let RunHandle { replayed, handle } =
+                    vm.sys_run("my-side-effect".to_owned()).unwrap();
+                assert!(!replayed);
                 assert!(vm
                     .propose_run_completion(
                         handle,
@@ -1163,7 +1241,9 @@ mod retry_policy {
                     .unwrap();
 
                 // Now try to enter run
-                let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+                let RunHandle { replayed, handle } =
+                    vm.sys_run("my-side-effect".to_owned()).unwrap();
+                assert!(!replayed);
 
                 assert!(vm
                     .propose_run_completion(
@@ -1219,19 +1299,11 @@ mod retry_policy {
                 result_completion_id: 1,
                 name: "my-side-effect".to_string(),
             })
-            .input(RunCompletionNotificationMessage {
-                completion_id: 1,
-                result: Some(run_completion_notification_message::Result::Failure(
-                    Failure {
-                        code: 500,
-                        message: "my-error".to_string(),
-                        metadata: vec![],
-                    },
-                )),
-            })
             .run(|vm| {
                 vm.sys_input().unwrap();
-                let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+                let RunHandle { replayed, handle } =
+                    vm.sys_run("my-side-effect".to_owned()).unwrap();
+                assert!(!replayed);
                 assert!(vm
                     .propose_run_completion(
                         handle,
@@ -1312,7 +1384,8 @@ mod retry_policy {
         vm.notify_input(encoder.encode(&input_entry_message(b"my-data")));
         vm.notify_input_closed();
         vm.sys_input().unwrap();
-        let handle = vm.sys_run("my-side-effect".to_owned()).unwrap();
+        let RunHandle { replayed, handle } = vm.sys_run("my-side-effect".to_owned()).unwrap();
+        assert!(!replayed);
 
         let err = vm
             .propose_run_completion(

--- a/src/tests/suspensions.rs
+++ b/src/tests/suspensions.rs
@@ -54,8 +54,8 @@ fn trigger_suspension_with_correct_awakeable() {
         .run_without_closing_input(|vm, _| {
             vm.sys_input().unwrap();
 
-            let (_, _h1) = vm.sys_awakeable().unwrap();
-            let (_, h2) = vm.sys_awakeable().unwrap();
+            let _h1 = vm.sys_awakeable().unwrap().handle;
+            let h2 = vm.sys_awakeable().unwrap().handle;
 
             // Also take_async_result returns Ok(None)
             assert_that!(vm.take_notification(h2), ok(none()));
@@ -91,7 +91,7 @@ fn await_many_notifications() {
         .run_without_closing_input(|vm, _| {
             vm.sys_input().unwrap();
 
-            let (_, h1) = vm.sys_awakeable().unwrap();
+            let h1 = vm.sys_awakeable().unwrap().handle;
             let h2 = vm.create_signal_handle("abc".into()).unwrap();
             let h3 = vm
                 .sys_state_get("Personaggio".to_owned(), PayloadOptions::default())
@@ -149,8 +149,8 @@ fn when_notify_completion_then_notify_await_point_then_notify_input_closed_then_
         .run_without_closing_input(|vm, encoder| {
             vm.sys_input().unwrap();
 
-            let (_, h1) = vm.sys_awakeable().unwrap();
-            let (_, h2) = vm.sys_awakeable().unwrap();
+            let h1 = vm.sys_awakeable().unwrap().handle;
+            let h2 = vm.sys_awakeable().unwrap().handle;
 
             // Do progress will ask for more input
             assert_that!(

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -17,11 +17,11 @@ use crate::vm::errors::{
 use crate::vm::run_state::RunState;
 use crate::vm::transitions::*;
 use crate::{
-    AttachInvocationTarget, AwaitResponse, CallHandle, CommandRelationship, Error, Header,
-    ImplicitCancellationOption, Input, NonDeterministicChecksOption, NonEmptyValue,
-    NotificationHandle, PayloadOptions, ResponseHead, RetryPolicy, RunExitResult, SendHandle,
-    TakeOutputResult, Target, TerminalFailure, UnresolvedFuture, VMOptions, VMResult, Value,
-    CANCEL_NOTIFICATION_HANDLE,
+    AttachInvocationTarget, AwaitResponse, AwakeableHandle, CallHandle, CommandRelationship, Error,
+    Header, ImplicitCancellationOption, Input, NonDeterministicChecksOption, NonEmptyValue,
+    NotificationHandle, PayloadOptions, ResponseHead, RetryPolicy, RunExitResult, RunHandle,
+    SendHandle, TakeOutputResult, Target, TerminalFailure, UnresolvedFuture, VMOptions, VMResult,
+    Value, CANCEL_NOTIFICATION_HANDLE,
 };
 use async_results_state::AsyncResultsState;
 use base64::engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig};
@@ -923,7 +923,7 @@ impl super::VM for CoreVM {
         ),
         ret
     )]
-    fn sys_awakeable(&mut self) -> VMResult<(String, NotificationHandle)> {
+    fn sys_awakeable(&mut self) -> VMResult<AwakeableHandle> {
         invocation_debug_logs!(self, "Executing 'Create awakeable'");
 
         let signal_id = self.context.journal.next_signal_notification_id();
@@ -933,10 +933,10 @@ impl super::VM for CoreVM {
             NotificationId::SignalId(signal_id),
         ))?;
 
-        Ok((
-            awakeable_id_str(&self.context.expect_start_info().id, signal_id),
+        Ok(AwakeableHandle {
+            id: awakeable_id_str(&self.context.expect_start_info().id, signal_id),
             handle,
-        ))
+        })
     }
 
     #[instrument(
@@ -1135,12 +1135,12 @@ impl super::VM for CoreVM {
         ),
         ret
     )]
-    fn sys_run(&mut self, name: String) -> VMResult<NotificationHandle> {
+    fn sys_run(&mut self, name: String) -> VMResult<RunHandle> {
         match self.do_transition(SysRun(name.clone())) {
             Ok(handle) => {
-                if enabled!(Level::DEBUG) {
+                if enabled!(Level::DEBUG) && !handle.replayed {
                     // Store the name, we need it later when completing
-                    self.sys_run_names.insert(handle, name);
+                    self.sys_run_names.insert(handle.handle, name);
                 }
                 Ok(handle)
             }
@@ -1166,10 +1166,9 @@ impl super::VM for CoreVM {
         retry_policy: RetryPolicy,
     ) -> VMResult<()> {
         if enabled!(Level::DEBUG) {
-            let name: &str = self
+            let name = self
                 .sys_run_names
-                .get(&notification_handle)
-                .map(String::as_str)
+                .remove(&notification_handle)
                 .unwrap_or_default();
             match &value {
                 RunExitResult::Success(_) => {

--- a/src/vm/transitions/journal.rs
+++ b/src/vm/transitions/journal.rs
@@ -22,7 +22,7 @@ use crate::vm::transitions::{Transition, TransitionAndReturn};
 use crate::vm::State;
 use crate::{
     CommandRelationship, CommandType, EntryRetryInfo, Error, Header, Input, NotificationHandle,
-    PayloadOptions, RetryPolicy, RunExitResult, Version,
+    PayloadOptions, RetryPolicy, RunExitResult, RunHandle, Version,
 };
 use bytes::Bytes;
 use std::collections::VecDeque;
@@ -668,7 +668,7 @@ fn process_get_entry_keys_during_replay(
 pub(crate) struct SysRun(pub(crate) String);
 
 impl TransitionAndReturn<Context, SysRun> for State {
-    type Output = NotificationHandle;
+    type Output = RunHandle;
 
     fn transition_and_return(
         self,
@@ -690,10 +690,21 @@ impl TransitionAndReturn<Context, SysRun> for State {
 
         let notification_id = NotificationId::CompletionId(result_completion_id);
         let mut needs_execution = true;
-        if let State::Replaying { async_results, .. } = &mut s {
-            // If we're replying,
-            // we need to check whether there is a completion already,
-            // otherwise enqueue it to execute it.
+        if let State::Replaying { async_results, .. } | State::Processing { async_results, .. } =
+            &mut s
+        {
+            // Previously in the shared core we used to do this non_deterministic_find_id check only in replaying,
+            // but now we do it either in replaying or processing. Why is it safe?
+            //
+            // * non_deterministic_find_id returns true iff the completion is in the journal, looking at prefix and suffix of the currently known journal:
+            //      * If we're replaying, we have all the replayed journal prefix at hand (because we pre-load it).
+            //      * If we're processing, we have all the replayed journal prefix at hand PLUS commands we have executed in this attempt and various notifications.
+            // * If non_deterministic_find_id returns true, then the completion must be in the journal, that means either:
+            //      * We're replaying, and the completion was already in the journal
+            //          -> in that case needs_execution = false is correct because the run closure was executed in a previous attempt.
+            //      * We're processing, and the completion was already in the journal
+            //          -> In that case either we transitioned to processing (we do that on sys_*, not on do_await!) and the completion was in the replayed journal prefix.
+            //          -> or we executed the run closure in this attempt. But this contradicts the ordering of events: sys_run gets called before propose_run_completion for that run!
             if async_results.non_deterministic_find_id(&notification_id) {
                 trace!(
                     "Found notification for {handle:?} with id {notification_id:?} while replaying, the run closure won't be executed."
@@ -718,7 +729,13 @@ impl TransitionAndReturn<Context, SysRun> for State {
             };
         }
 
-        Ok((s, handle))
+        Ok((
+            s,
+            RunHandle {
+                replayed: !needs_execution,
+                handle,
+            },
+        ))
     }
 }
 


### PR DESCRIPTION
This should be used by SDKs to decide whether we should keep around the run closure to execute or not.

Also update sys_awakeable interface with named struct.